### PR TITLE
Fixed registry key path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Versions
+
+### Unreleased
+
+### 1.0.0.1
+
+* Modified Windows-All-IE11-1.15.xml

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ### Unreleased
 
 * Modified Windows-All-IE11-1.15.xml
+    * Changed registry key in rule V-46477 from 'Software Publishing Criteria' to 'Software Publishing'
 
 ### 1.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ### Unreleased
 
-### 1.0.0.1
-
 * Modified Windows-All-IE11-1.15.xml
+
+### 1.0.0.0
 
 Added the following STIGs:
 

--- a/StigData/Windows-All-IE11-1.15.xml
+++ b/StigData/Windows-All-IE11-1.15.xml
@@ -29,7 +29,7 @@ If the value for "SecureProtocols" is not REG_DWORD = "2560", this is a finding.
     <Rule id="V-46477" severity="low" conversionstatus="pass" title="DTBI018-IE11-Publishers Certificate Revocation" dscresource="Registry">
       <Ensure>Present</Ensure>
       <IsNullOrEmpty>False</IsNullOrEmpty>
-      <Key>HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\WinTrust\Trust Providers\Software Publishing Criteria</Key>
+      <Key>HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\WinTrust\Trust Providers\Software Publishing</Key>
       <OrganizationValueRequired>False</OrganizationValueRequired>
       <OrganizationValueTestString />
       <rawString>If the system is on the SIPRNet, this requirement is NA.


### PR DESCRIPTION
Software Publishing Criteria key doesn't exist. It's just Software Publishing. The stig info is misleading on the disa site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/2)
<!-- Reviewable:end -->
