### PR TITLE
Changed filename output from Split-StigXccdf (fixes #19)

### DIFF
--- a/Module/Convert.Main/Functions.XccdfXml.ps1
+++ b/Module/Convert.Main/Functions.XccdfXml.ps1
@@ -146,11 +146,15 @@ function Split-StigXccdf
         }
 
         #region save the split stig file
-        $Destination = $Destination.TrimEnd("\")
-        $FilePathRoot = "$($msStig.Benchmark.id)_{0}.xml"
+        $Destination = Resolve-Path -Path $Destination.TrimEnd("\")
+        $fileName = $Path | Split-Path -Leaf
 
-        $msStig.Save("$Destination\$FilePathRoot" -f "MS")
-        $dcStig.Save("$Destination\$FilePathRoot" -f "DC")
+        $fileNameLeaf = ($fileName | Select-String -Pattern '(?<=2016_).*$').Matches.Groups[-1].Value.Trim()
+        $fileNameParent = ($fileName | Select-String -Pattern '.*(?=STIG)').Matches.Groups[-1].Value.Trim()
+        $fileNameRoot = "$fileNameParent{0}_$fileNameLeaf"
+
+        $msStig.Save("$Destination\$fileNameRoot" -f "MS")
+        $dcStig.Save("$Destination\$fileNameRoot" -f "DC")
         #endregion
     }
     End

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ See our [contributing guide](CONTRIBUTING.md) for more info on how to become a D
 
 ### Unreleased
 
+* Modified Split-StigXccdf function
+    * Output filenames are now consistent with ConvertTo-PowerStigXml
+
 ### 1.0.0.0
 
 Added the following STIGs:


### PR DESCRIPTION
This change keeps filenames consistent between this function and ConvertTo-PowerStigXml. Fixes #19.