### PR TITLE
Added MS/DC to split stig benchmark id

### DIFF
--- a/Module/Convert.Main/Functions.PowerStigXml.ps1
+++ b/Module/Convert.Main/Functions.PowerStigXml.ps1
@@ -521,6 +521,24 @@ function Split-BenchmarkId
         '(_+)Security_Technical_Implementation_Guide_NewBenchmark',
         '(_+)Security_Technical_Implementation_Guide'
     )
+    $sqlServerVariations = @(
+        'Microsoft_SQL_Server'
+    )
+    $sqlServerInstanceVariations = @(
+        'Database_Instance'
+    )
+    $windowsVariations = @(
+        'Microsoft_Windows',
+        'Windows_Server',
+        'Windows'
+    )
+    $dnsServerVariations = @(
+        'Server_Domain_Name_System',
+        'Domain_Name_System'
+    )
+    $activeDirectoryVariations = @(
+        'Active_Directory'
+    )
 
     $Id = $Id -replace ($idVariations -join '|'), ''
 
@@ -528,14 +546,7 @@ function Split-BenchmarkId
     {
         {$PSItem -match "SQL_Server"}
         {
-            $sqlServerVariations = @(
-                'Microsoft_SQL_Server'
-            )
             $returnId = $Id -replace ($sqlServerVariations -join '|'), 'SqlServer'
-
-            $sqlServerInstanceVariations = @(
-                'Database_Instance'
-            )
             $returnId = $returnId -replace ($sqlServerInstanceVariations -join '|'), 'Instance'
             continue
         }
@@ -546,40 +557,23 @@ function Split-BenchmarkId
         }
         {$PSItem -match "Domain_Name_System"}
         {
-            $windowsVariations = @(
-                'Microsoft_Windows',
-                'Windows'
-            )
-            $dnsServerVariations = @(
-                'Server_Domain_Name_System',
-                'Domain_Name_System'
-            )
             $returnId = $Id -replace ($dnsServerVariations -join '|'), 'DNS'
             $returnId = $returnId -replace ($windowsVariations -join '|'), 'Windows'
             continue
         }
         {$PSItem -match "Windows"}
         {
-            $windowsVariations = @(
-                'Windows'
-            )
             $returnId = $Id -replace ($windowsVariations -join '|'), 'Windows'
-
             continue
         }
         {$PSItem -match "Active_Directory"}
         {
-            $activeDirectoryVariations = @(
-                'Active_Directory'
-            )
             $returnId = $Id -replace ($activeDirectoryVariations -join '|'), 'Windows_All'
-
             continue
         }
         {$PSItem -match "IE_"}
         {
             $returnId = "Windows_All_" + -join ($Id -split '_')
-
             continue
         }
         default

--- a/Module/Convert.Main/Functions.PowerStigXml.ps1
+++ b/Module/Convert.Main/Functions.PowerStigXml.ps1
@@ -1,9 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
-#region Header
-
-#endregion
 #region Main Function
 <#
     .SYNOPSIS

--- a/Module/Convert.Main/Functions.Report.ps1
+++ b/Module/Convert.Main/Functions.Report.ps1
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
 #region Public Function
 <#
     .SYNOPSIS

--- a/Module/Convert.Main/Functions.XccdfXml.ps1
+++ b/Module/Convert.Main/Functions.XccdfXml.ps1
@@ -97,7 +97,7 @@ function ConvertFrom-StigXccdf
 function Split-StigXccdf
 {
     [CmdletBinding()]
-    [OutputType([object])]
+    [OutputType([null])]
     Param
     (
         [parameter(Mandatory = $true)]
@@ -159,10 +159,10 @@ function Split-StigXccdf
             $Destination = $Destination.TrimEnd("\")
         }
 
-        $FilePathRoot = Split-Path -Path $Path -Leaf
+        $FilePath = "$Destination\$(Split-Path -Path $Path -Leaf)"
 
-        $msStig.Save(("$Destination\$FilePathRoot" -replace '2016_STIG', '2016_MS_SPLIT_STIG'))
-        $dcStig.Save(("$Destination\$FilePathRoot" -replace '2016_STIG', '2016_DC_SPLIT_STIG'))
+        $msStig.Save(($FilePath -replace '2016_STIG', '2016_MS_SPLIT_STIG'))
+        $dcStig.Save(($FilePath -replace '2016_STIG', '2016_DC_SPLIT_STIG'))
     }
     End
     {

--- a/Module/Convert.Main/Functions.XccdfXml.ps1
+++ b/Module/Convert.Main/Functions.XccdfXml.ps1
@@ -97,7 +97,6 @@ function ConvertFrom-StigXccdf
 function Split-StigXccdf
 {
     [CmdletBinding()]
-    [OutputType([null])]
     Param
     (
         [parameter(Mandatory = $true)]

--- a/Module/Convert.Main/Functions.XccdfXml.ps1
+++ b/Module/Convert.Main/Functions.XccdfXml.ps1
@@ -1,8 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
-#region Header
-#endregion
 #region Main Function
 <#
     .SYNOPSIS
@@ -127,31 +124,45 @@ function Split-StigXccdf
         [xml] $msStig = Get-Content -Path $Path
         [xml] $dcStig = $msStig.Clone()
 
+        # Update the benchmark ID to reflect the STIG content
+        $dcStig.Benchmark.id = $msStig.Benchmark.id -replace '_STIG', '_DC_STIG'
+        $msStig.Benchmark.id = $msStig.Benchmark.id -replace '_STIG', '_MS_STIG'
+
         # Remove DC only settings from the MS xml
+        Write-Information -MessageData "Removing Domain Controller settings from Member Server STIG"
         foreach ($group in $msStig.Benchmark.Group)
         {
             if ($group.Rule.check.'check-content' -match "This applies to domain controllers")
             {
-                $msStig.Benchmark.RemoveChild($group)
+                [void] $msStig.Benchmark.RemoveChild($group)
+                Write-Information -MessageData "Removing $($group.id)"
             }
         }
 
         # Remove DC only setting from the MS xml
+        Write-Information -MessageData "Removing Member Server settings from Domain Controller STIG"
         foreach ($group in $dcStig.Benchmark.Group)
         {
             if ($group.Rule.check.'check-content' -match "This applies to member servers")
             {
-                $dcStig.Benchmark.RemoveChild($group)
+                [void] $dcStig.Benchmark.RemoveChild($group)
+                Write-Information -MessageData "Removing $($group.id)"
             }
         }
 
-        #region save the split stig file
-        $Destination = $Destination.TrimEnd("\")
-        $FilePathRoot = "$($msStig.Benchmark.id)_{0}.xml"
+        if ([string]::IsNullOrEmpty($Destination))
+        {
+            $Destination = Split-Path -Path $Path -Parent
+        }
+        else
+        {
+            $Destination = $Destination.TrimEnd("\")
+        }
 
-        $msStig.Save("$Destination\$FilePathRoot" -f "MS")
-        $dcStig.Save("$Destination\$FilePathRoot" -f "DC")
-        #endregion
+        $FilePathRoot = Split-Path -Path $Path -Leaf
+
+        $msStig.Save(("$Destination\$FilePathRoot" -replace '2016_STIG', '2016_MS_SPLIT_STIG'))
+        $dcStig.Save(("$Destination\$FilePathRoot" -replace '2016_STIG', '2016_DC_SPLIT_STIG'))
     }
     End
     {

--- a/Tests/Unit/Module/Convert.Main.tests.ps1
+++ b/Tests/Unit/Module/Convert.Main.tests.ps1
@@ -136,6 +136,18 @@ try
                         'Technology' = 'Windows'
                         'TechnologyVersion' = '2012'
                         'TechnologyRole' = 'MS'
+                    },
+                    @{
+                        'id' = 'Windows_Server_2016_DC_STIG'
+                        'Technology' = 'Windows'
+                        'TechnologyVersion' = '2016'
+                        'TechnologyRole' = 'DC'
+                    },
+                    @{
+                        'id' = 'Windows_Server_2016_MS_STIG'
+                        'Technology' = 'Windows'
+                        'TechnologyVersion' = '2016'
+                        'TechnologyRole' = 'MS'
                     }
                 )
                 'Active_Directory' = @(

--- a/Tests/Unit/Module/Convert.Main.tests.ps1
+++ b/Tests/Unit/Module/Convert.Main.tests.ps1
@@ -15,11 +15,42 @@ try
 
         #endregion
         #region Function Tests
+        Describe 'Split-StigXccdf' {
+
+            $sampleXccdfFileName = 'U_Windows_Server_2016{0}_STIG_V1R1_Manual-xccdf.xml'
+            $sampleXccdfId = 'Windows_Server_2016{0}_STIG'
+            $sampleXccdfPath = "$TestDrive\$sampleXccdfFileName" -f ''
+            (Get-TestStigRule -XccdfId ($sampleXccdfId -f '')).Save($sampleXccdfPath)
+            Split-StigXccdf -Path $sampleXccdfPath
+
+            Context 'Member Server' {
+                $sampleXccdfSplitPath = "$TestDrive\$sampleXccdfFileName" -f '_MS_SPLIT'
+                It 'Should create an MS STIG file' {
+                    Test-Path -Path $sampleXccdfSplitPath | Should Be $true
+                }
+
+                It 'Should have MS in the benchmark ID' {
+                    [xml] $sampleXccdfSplitContent = Get-Content $sampleXccdfSplitPath -Encoding UTF8 -Raw
+                    $sampleXccdfSplitContent.Benchmark.id | Should Be ($sampleXccdfId -f '_MS')
+                }
+            }
+
+            Context 'Domain Controller' {
+                $sampleXccdfSplitPath = "$TestDrive\$sampleXccdfFileName" -f '_DC_SPLIT'
+                It 'Should create an DC STIG file' {
+                    Test-Path -Path $sampleXccdfSplitPath | Should Be $true
+                }
+                It 'Should have DC in the benchmark ID' {
+                    [xml] $sampleXccdfSplitContent = Get-Content $sampleXccdfSplitPath -Encoding UTF8 -Raw
+                    $sampleXccdfSplitContent.Benchmark.id | Should Be ($sampleXccdfId -f '_DC')
+                }
+            }
+        }
         Describe "Get-StigVersionNumber" {
             $majorVersionNumber = '1'
             $minorVersionNumber = '5'
             $sampleXccdf = Get-TestStigRule -XccdfVersion $majorVersionNumber `
-                                            -XccdfRelease "Release: $minorVersionNumber Benchmark Date: 01 Jan 1901"
+                -XccdfRelease "Release: $minorVersionNumber Benchmark Date: 01 Jan 1901"
 
             It "Should extract the version number from the xccdf" {
                 Get-StigVersionNumber -StigDetails $sampleXccdf |
@@ -31,8 +62,8 @@ try
             $majorVersionNumber = '1'
             $minorVersionNumber = '5'
             $sampleXccdf = Get-TestStigRule -XccdfVersion $majorVersionNumber `
-                                            -XccdfRelease "Release: $minorVersionNumber Benchmark Date: 01 Jan 1901" `
-                                            -XccdfId "Windows_2012_DC_STIG"
+                -XccdfRelease "Release: $minorVersionNumber Benchmark Date: 01 Jan 1901" `
+                -XccdfId "Windows_2012_DC_STIG"
             $expectedName = "Windows-2012-DC-$majorVersionNumber.$minorVersionNumber.xml"
             Context 'No Destination supplied' {
 


### PR DESCRIPTION
Resolves #25 

Updated `Split-StigXccdf` to apply the correct benchmark id 
Added tests
Removed empty header regions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/26)
<!-- Reviewable:end -->
