### PR TITLE
updated event log name match

### DIFF
--- a/Module/Common/Data.ps1
+++ b/Module/Common/Data.ps1
@@ -197,3 +197,17 @@ data webRegularExpression
         inetpub                 = inetpub
 '@
 }
+
+data eventLogRegularExpression
+{
+    <#
+        The name entry was added to support event log name extraction from the
+        different formats found in different Window Server STIGs. For example in
+        the 2012 Stig, (Application.evtx) was used, in 2016 “Application.evtx”
+        is used, so name now extracts the log name from the extension and the
+        preceding word.
+    #>
+    ConvertFrom-StringData -stringdata @'
+        name = \\w+\\.evtx
+'@
+}

--- a/Module/Convert.PermissionRule/Methods.ps1
+++ b/Module/Convert.PermissionRule/Methods.ps1
@@ -25,7 +25,7 @@ function Get-PermissionTargetPath
         # get path for permissions that pertains to event logs
         { $stigString -match $script:RegularExpression.WinEvtDirectory }
         {
-            $parentheseMatch = $StigString | Select-String -Pattern $script:RegularExpression.textBetweenParentheses
+            $parentheseMatch = $StigString | Select-String -Pattern $script:eventLogRegularExpression.name
 
             if ( $StigString -match $script:RegularExpression.dnsServerLog )
             {

--- a/Tests/Unit/Module/Common.tests.ps1
+++ b/Tests/Unit/Module/Common.tests.ps1
@@ -3,18 +3,18 @@ using module .\..\..\..\Module\Common\Common.psm1
 . $PSScriptRoot\.tests.Header.ps1
 #endregion
 #region Enum Tests
-<# 
+<#
     a list of enums in the script that is used in a "burn down" manner. When an enum is processed
-    it is removed from the list, The last test will be to verify that all of the enums have 
+    it is removed from the list, The last test will be to verify that all of the enums have
     been tested
 #>
 $enumDiscovered = New-Object System.Collections.ArrayList
-# select each line that starts with enum to count the number of enum's in the file 
+# select each line that starts with enum to count the number of enum's in the file
 
 $enumListString = ( Get-Content $modulePath | Select-String "^Enum " )
 # add each enum that is found to the array
 $enumListString | Foreach-Object { $enumDiscovered.add( ( $_ -split " " )[1].ToString().ToLower() ) | Out-Null }
-# get a count to to use in a final test to validate enum test coverage 
+# get a count to to use in a final test to validate enum test coverage
 [int] $enumTestCount = $enumDiscovered.Count
 
 $enumTests = @{
@@ -40,7 +40,7 @@ foreach( $enum in $enumTests.GetEnumerator() )
         #[process].GetEnumValues()
         $EnumValues = [enum]::GetValues($enum.Key)
 
-        foreach ( $value in $EnumValues ) 
+        foreach ( $value in $EnumValues )
         {
             It "$value should exist" {
                 $value | should match $enum.Value
@@ -62,21 +62,21 @@ Describe 'Enum coverage' {
 #endregion Tests
 #region Data Tests
 Describe "RegularExpression Data Section" {
-    
+
     [string] $dataSectionName = 'RegularExpression'
 
     It "Should have a data section called $dataSectionName" {
-        ( get-variable $dataSectionName ).Name | Should Be $dataSectionName
+        ( Get-Variable -Name $dataSectionName ).Name | Should Be $dataSectionName
     }
 
     Context 'Hex Code' {
 
         It 'Should match a hexcode' {
-            '0X00000000' -Match $RegularExpression.hexCode | Should Be $true  
+            '0X00000000' -Match $RegularExpression.hexCode | Should Be $true
         }
 
         It 'Should NOT match nonhexcode' {
-            '0X000000000' -Match $RegularExpression.hexCode | Should Be $false  
+            '0X000000000' -Match $RegularExpression.hexCode | Should Be $false
         }
     }
 
@@ -96,12 +96,12 @@ Describe "RegularExpression Data Section" {
     }
 
     Context "Blank String" {
-        
+
         It "Should match '(Blank)' literal string" {
             "(Blank)" -Match $RegularExpression.blankString | Should Be $true
         }
     }
-    
+
     Context 'Enabled or Disabled String' {
 
         foreach ( $flag in ('Enabled','enabled','Disabled','disabled') )
@@ -120,7 +120,7 @@ Describe "RegularExpression Data Section" {
                 $flag -Match $RegularExpression.AuditFlag | Should Be $true
             }
         }
-        
+
         $audiPolicyStringFormats = @(
             'Catagory -> Sub Category - Flag',
             'Catagory >> Sub Category - Flag'
@@ -152,60 +152,85 @@ Describe "RegularExpression Data Section" {
             $text = 'InsideOfParenthese'
             $unneededText = 'Unneeded text'
 
-            $result = ( "$unneededText (" + $text + ") $unneededText" | 
+            $result = ( "$unneededText (" + $text + ") $unneededText" |
                 Select-String $RegularExpression.textBetweenParentheses ).matches.groups[-1].Value
 
             $result | Should Be $text
         }
     }
 
-    <# 
-    TO DO - Add rules 
+    <#
+    TO DO - Add rules
     #>
 }
 
 Describe "rangeMatch Data Section" {
-    
+
     [string] $dataSectionName = 'rangeMatch'
 
     It "should have a data section called $dataSectionName" {
         ( Get-Variable -Name $dataSectionName ).Name | Should Be $dataSectionName
     }
 
-    <# 
-    TO DO - Add rules 
+    <#
+    TO DO - Add rules
     #>
 }
 
 Describe "errorMessage Data Section" {
-    
+
     [string] $dataSectionName = 'errorMessage'
 
     It "should have a data section called $dataSectionName" {
         ( Get-Variable -Name $dataSectionName ).Name | Should Be $dataSectionName
     }
 
-    <# 
-    TO DO - Add rules 
+    <#
+    TO DO - Add rules
     #>
 }
 
 Describe "ADAuditPath Data Section" {
-    
+
     [string] $dataSectionName = 'ADAuditPath'
 
     It "should have a data section called $dataSectionName" {
         ( Get-Variable -Name $dataSectionName ).Name | Should Be $dataSectionName
     }
 
-    <# 
-    TO DO - Add rules 
+    <#
+    TO DO - Add rules
     #>
+}
+
+Describe "eventLogRegularExpression Data Section" {
+
+    [string] $dataSectionName = 'eventLogRegularExpression'
+    It "should have a data section called $dataSectionName" {
+        ( Get-Variable -Name $dataSectionName ).Name | Should Be $dataSectionName
+    }
+
+    $namesToTest = @(
+        '(Application.evtx)',
+        '"Application.evtx"',
+        '''(System.evtx)''',
+        '''("System.evtx")'''
+    )
+    Context 'Name' {
+
+        foreach($name in $namesToTest)
+        {
+            It "Should match $name" {
+                $name -Match $eventLogRegularExpression.name | Should Be $true
+            }
+        }
+
+    }
 }
 #endregion Tests
 #region Helper Tests
 Describe 'Get-AvailableId' {
-    # Since this function uses a global variable, we need to make sure we don't step on anything. 
+    # Since this function uses a global variable, we need to make sure we don't step on anything.
     $resetglobalSettings = $false
     if ( $global:stigSettings )
     {
@@ -213,7 +238,7 @@ Describe 'Get-AvailableId' {
         $resetglobalSettings = $true
     }
 
-    try 
+    try
     {
         It 'Should add the next available letter to an Id' {
             $global:stigSettings = @(@{Id = 'V-1000'})


### PR DESCRIPTION
This PR resolves #11 
I created a new regex that extracts the event log name from the extension instead of the location in a string. 
I created a new test for the new data section and added test data to validate a few different representations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/31)
<!-- Reviewable:end -->
