### PR TITLE
updates to incorporate Sql Stigs in PowerStigDsc

### DIFF
--- a/Module/Common/Common.psm1
+++ b/Module/Common/Common.psm1
@@ -89,7 +89,7 @@ Enum RuleType
 enum Technology
 {
     Windows
-    SQL
+    SqlServer
 }
 
 #endregion

--- a/Module/Stig.TechnologyRole/Stig.TechnologyRole.psm1
+++ b/Module/Stig.TechnologyRole/Stig.TechnologyRole.psm1
@@ -42,7 +42,7 @@ Class TechnologyRole
     static $ValidateSet = @"
 2012R2 = DNS, DC, MS, IISSite, IISServer
 All = ADDomain, ADForest, FW, IE11
-Server2012 = Instance, Database
+2012 = Instance, Database
 "@
     #endregion
     #region Constructors

--- a/Module/Stig.TechnologyVersion/Stig.TechnologyVersion.psm1
+++ b/Module/Stig.TechnologyVersion/Stig.TechnologyVersion.psm1
@@ -40,7 +40,7 @@ Class TechnologyVersion
     #>
     static $ValidateSet = @"
 Windows = All, 2012R2
-SQL = Server2012
+SqlServer = 2012
 "@
     #endregion
     #region Constructors

--- a/PowerStig.psm1
+++ b/PowerStig.psm1
@@ -5,6 +5,7 @@ using module .\Module\Common\Common.psm1
 using module .\Module\Stig.OrganizationalSetting\Stig.OrganizationalSetting.psm1
 using module .\Module\Stig.SkippedRule\Stig.SkippedRule.psm1
 using module .\Module\Stig.SkippedRuleType\Stig.SkippedRuleType.psm1
+using module .\Module\Stig.StigData\Stig.StigData.psm1 
 using module .\Module\Stig.StigException\Stig.StigException.psm1
 using module .\Module\Stig.TechnologyRole\Stig.TechnologyRole.psm1
 using module .\Module\Stig.TechnologyVersion\Stig.TechnologyVersion.psm1

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Added the following STIGs:
 
 * IIS 8.5 Server STIG V1R3
 
+Updates
+
+* Updated SQL STIG code to account for SQL STIGS being added in PowerStigDsc
+* Update to PowerStig.psm1 to fix issue were StigData class was not accessible to PowerStigDsc
+
 ### 1.0.0.0
 
 Added the following STIGs:

--- a/Tests/Integration/Convert.Main.Integration.tests.ps1
+++ b/Tests/Integration/Convert.Main.Integration.tests.ps1
@@ -339,7 +339,7 @@ try
             RegistryRule                 = 5
             SecurityOptionRule           = $null
             ServiceRule                  = $null
-            SqlScriptRule                = $null
+            SqlScriptQueryRule                = $null
             UserRightRule                = $null
             WebAppPoolRule               = $null
             WebConfigurationPropertyRule = 10

--- a/Tests/Unit/Module/Stig.TechnologyRole.tests.ps1
+++ b/Tests/Unit/Module/Stig.TechnologyRole.tests.ps1
@@ -13,16 +13,16 @@ try
         $technologyRole3 = 'Instance'
 
         $Technology1 = [Technology]::Windows
-        $Technology2 = [Technology]::SQL
+        $Technology2 = [Technology]::SqlServer
 
         $technologyVersion1 = [TechnologyVersion]::new('2012R2', $Technology1)
         $technologyVersion2 = [TechnologyVersion]::new('All', $Technology1)
-        $technologyVersion3 = [TechnologyVersion]::new('Server2012', $Technology2)
+        $technologyVersion3 = [TechnologyVersion]::new('2012', $Technology2)
 
         $TestValidateSet = @"
 2012R2 = DNS, DC, MS, IISSite, IISServer
 All = ADDomain, ADForest, FW, IE11
-Server2012 = Instance, Database
+2012 = Instance, Database
 "@
 
         $TestValidSetData = ConvertFrom-StringData -StringData $TestValidateSet

--- a/Tests/Unit/Module/Stig.TechnologyVersion.tests.ps1
+++ b/Tests/Unit/Module/Stig.TechnologyVersion.tests.ps1
@@ -10,14 +10,14 @@ try
         #region Test Setup
         $TechnologyVersion1 = 'All'
         $TechnologyVersion2 = '2012R2'
-        $TechnologyVersion3 = 'Server2012'
+        $TechnologyVersion3 = '2012'
 
         $Technology1 = [Technology]::Windows
-        $Technology2 = [Technology]::SQL
+        $Technology2 = [Technology]::SqlServer
 
         $TestValidateSet = @"
 Windows = All, 2012R2
-SQL = Server2012
+SqlServer = 2012
 "@
 
         $TestValidSetData = ConvertFrom-StringData -StringData $TestValidateSet


### PR DESCRIPTION
There was an issue with the stig data class not being accessible due to the module not being called in the main PowerSTIG module. This is remedied here as well as an update to the conversion integration tests were a rule was misnamed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/43)
<!-- Reviewable:end -->
