### PR TITLE
Fixes #212 SDDL strings are incorrectly split in the xRegistry resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed (#212) SDDL strings are incorrectly split in the xRegistry resource
+
 ## 2.3.0.0
 
 * Windows 10 Fixes

--- a/DSCResources/Resources/windows.xRegistry.ps1
+++ b/DSCResources/Resources/windows.xRegistry.ps1
@@ -7,7 +7,7 @@ foreach ( $rule in $rules )
 {
     if ($rule.Key -match "^HKEY_LOCAL_MACHINE")
     {
-        If ($rule.ValueType -eq 'MultiString')
+        if ($rule.ValueType -eq 'MultiString')
         {
             $valueData = $rule.ValueData.Split("{;}")
         }

--- a/DSCResources/Resources/windows.xRegistry.ps1
+++ b/DSCResources/Resources/windows.xRegistry.ps1
@@ -7,16 +7,19 @@ foreach ( $rule in $rules )
 {
     if ($rule.Key -match "^HKEY_LOCAL_MACHINE")
     {
-        $valueData = $rule.ValueData.Split("{;}")
+        If ($rule.ValueType -eq 'MultiString')
+        {
+            $rule.ValueData = $rule.ValueData.Split("{;}")
+        }
 
         xRegistry (Get-ResourceTitle -Rule $rule)
         {
             Key       = $rule.Key
             ValueName = $rule.ValueName
-            ValueData = $valueData
+            ValueData = $rule.ValueData
             ValueType = $rule.ValueType
             Ensure    = $rule.Ensure
-            Force     = $true  
+            Force     = $true
         }
     }
 }

--- a/DSCResources/Resources/windows.xRegistry.ps1
+++ b/DSCResources/Resources/windows.xRegistry.ps1
@@ -9,18 +9,18 @@ foreach ( $rule in $rules )
     {
         If ($rule.ValueType -eq 'MultiString')
         {
-            $ValueData = $rule.ValueData.Split("{;}")
+            $valueData = $rule.ValueData.Split("{;}")
         }
         else
         {
-            $ValueData = $rule.ValueData
+            $valueData = $rule.ValueData
         }
 
         xRegistry (Get-ResourceTitle -Rule $rule)
         {
             Key       = $rule.Key
             ValueName = $rule.ValueName
-            ValueData = $ValueData
+            ValueData = $valueData
             ValueType = $rule.ValueType
             Ensure    = $rule.Ensure
             Force     = $true

--- a/DSCResources/Resources/windows.xRegistry.ps1
+++ b/DSCResources/Resources/windows.xRegistry.ps1
@@ -9,14 +9,18 @@ foreach ( $rule in $rules )
     {
         If ($rule.ValueType -eq 'MultiString')
         {
-            $rule.ValueData = $rule.ValueData.Split("{;}")
+            $ValueData = $rule.ValueData.Split("{;}")
+        }
+        else
+        {
+            $ValueData = $rule.ValueData
         }
 
         xRegistry (Get-ResourceTitle -Rule $rule)
         {
             Key       = $rule.Key
             ValueName = $rule.ValueName
-            ValueData = $rule.ValueData
+            ValueData = $ValueData
             ValueType = $rule.ValueType
             Ensure    = $rule.Ensure
             Force     = $true

--- a/Tests/Unit/DSCResources/windows.xRegistry.config.ps1
+++ b/Tests/Unit/DSCResources/windows.xRegistry.config.ps1
@@ -1,0 +1,13 @@
+Configuration xRegistry_config
+{
+    param
+    ( )
+
+    Import-Module $PSScriptRoot\..\..\..\DscResources\helper.psm1 -Force
+    Import-DscResource -ModuleName xPSDesiredStateConfiguration -ModuleVersion 8.3.0.0
+
+    Node localhost
+    {
+        . $PSScriptRoot\..\..\..\DscResources\Resources\windows.xRegistry.ps1
+    }
+}

--- a/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
+++ b/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
@@ -3,40 +3,43 @@ $testDataRules = @(
     @{
         testXml = [xml]'<Rule Id="V-1000" severity="low" title="DWORD Test">
         <Ensure>Present</Ensure>
-        <IsNullOrEmpty>False</IsNullOrEmpty>
         <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
         <ValueData>0</ValueData>
         <ValueName>DwordValueName</ValueName>
         <ValueType>Dword</ValueType>
         </Rule>'
-        ValueName = 'DwordValueName'
+        Ensure = 'Present'
+        Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft'
         ValueData = '0'
+        ValueName = 'DwordValueName'
         ValueType = 'Dword'
     },
     @{
         testXml = [xml]'<Rule id="V-1000" severity="low" title="MultiString Test">
         <Ensure>Present</Ensure>
-        <IsNullOrEmpty>False</IsNullOrEmpty>
         <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
         <ValueData>123;ABC</ValueData>
         <ValueName>MultiStringValueName</ValueName>
         <ValueType>MultiString</ValueType>
-      </Rule>'
-        ValueName = 'MultiStringValueName'
+        </Rule>'
+        Ensure = 'Present'
+        Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft'
         ValueData = @('123', 'ABC')
+        ValueName = 'MultiStringValueName'
         ValueType = 'MultiString'
     },
     @{
         testXml = [xml]'<Rule id="V-1000" severity="low" title="String">
         <Ensure>Present</Ensure>
-        <IsNullOrEmpty>False</IsNullOrEmpty>
         <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
         <ValueData>O:BAG:BAD:(A;;RC;;;BA)</ValueData>
         <ValueName>StringValueName</ValueName>
         <ValueType>String</ValueType>
         </Rule>'
-        ValueName = 'StringValueName'
+        Ensure = 'Present'
+        Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft'
         ValueData = 'O:BAG:BAD:(A;;RC;;;BA)'
+        ValueName = 'StringValueName'
         ValueType = 'String'
     }
 )
@@ -62,12 +65,20 @@ Describe 'xRegistry call' {
 
             $instance = [Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ImportInstances($configurationDocumentPath, 4)
 
-            It 'Should set the correct Type' {
-                $instance[0].ValueType | Should Be $testData.ValueType
+            It 'Should set the correct Ensure flag' {
+                $instance[0].Ensure | Should Be $testData.Ensure
             }
-
+            It 'Should set the correct Key' {
+                $instance[0].Key | Should Be $testData.Key
+            }
             It 'Should set the correct Data' {
                 $instance[0].ValueData | Should Be $testData.ValueData
+            }
+            It 'Should set the correct Name' {
+                $instance[0].ValueName | Should Be $testData.ValueName
+            }
+            It 'Should set the correct Type' {
+                $instance[0].ValueType | Should Be $testData.ValueType
             }
         }
     }

--- a/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
+++ b/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
@@ -1,5 +1,5 @@
 
-$testDataRules = @(
+$ruleList = @(
     @{
         testXml = [xml]'<Rule Id="V-1000" severity="low" title="DWORD Test">
         <Ensure>Present</Ensure>
@@ -15,20 +15,6 @@ $testDataRules = @(
         ValueType = 'Dword'
     },
     @{
-        testXml = [xml]'<Rule id="V-1000" severity="low" title="MultiString Test">
-        <Ensure>Present</Ensure>
-        <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
-        <ValueData>123;ABC</ValueData>
-        <ValueName>MultiStringValueName</ValueName>
-        <ValueType>MultiString</ValueType>
-        </Rule>'
-        Ensure = 'Present'
-        Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft'
-        ValueData = @('123', 'ABC')
-        ValueName = 'MultiStringValueName'
-        ValueType = 'MultiString'
-    },
-    @{
         testXml = [xml]'<Rule id="V-1000" severity="low" title="String">
         <Ensure>Present</Ensure>
         <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
@@ -41,6 +27,20 @@ $testDataRules = @(
         ValueData = 'O:BAG:BAD:(A;;RC;;;BA)'
         ValueName = 'StringValueName'
         ValueType = 'String'
+    },
+    @{
+        testXml = [xml]'<Rule id="V-1000" severity="low" title="MultiString Test">
+        <Ensure>Present</Ensure>
+        <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
+        <ValueData>123;ABC</ValueData>
+        <ValueName>MultiStringValueName</ValueName>
+        <ValueType>MultiString</ValueType>
+        </Rule>'
+        Ensure = 'Present'
+        Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft'
+        ValueData = @('123', 'ABC')
+        ValueName = 'MultiStringValueName'
+        ValueType = 'MultiString'
     }
 )
 
@@ -49,35 +49,32 @@ $configFile = Join-Path -Path $PSScriptRoot -ChildPath "windows.xRegistry.config
 
 Describe 'xRegistry call' {
 
-    foreach ($testData in $testDataRules)
+    foreach ($rule in $ruleList)
     {
-        Context "$($testData.ValueType)" {
-
-            function Get-RuleClassData {}
-            Mock Get-RuleClassData -MockWith {$testData.testXml.Rule}
+        Context "$($rule.ValueType)" {
 
             It 'Should not throw' {
+                function Get-RuleClassData {}
+                Mock Get-RuleClassData -MockWith {$rule.testXml.Rule}
                 { & xRegistry_config -OutputPath $TestDrive } | Should Not Throw
             }
 
-            $configurationDocumentPath = "$TestDrive\localhost.mof"
-
-            $instance = [Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ImportInstances($configurationDocumentPath, 4)
+            $instance = ([Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ImportInstances("$TestDrive\localhost.mof", 4))[0]
 
             It 'Should set the correct Ensure flag' {
-                $instance[0].Ensure | Should Be $testData.Ensure
+                $instance.Ensure | Should Be $rule.Ensure
             }
             It 'Should set the correct Key' {
-                $instance[0].Key | Should Be $testData.Key
+                $instance.Key | Should Be $rule.Key
             }
             It 'Should set the correct Data' {
-                $instance[0].ValueData | Should Be $testData.ValueData
+                $instance.ValueData | Should Be $rule.ValueData
             }
             It 'Should set the correct Name' {
-                $instance[0].ValueName | Should Be $testData.ValueName
+                $instance.ValueName | Should Be $rule.ValueName
             }
             It 'Should set the correct Type' {
-                $instance[0].ValueType | Should Be $testData.ValueType
+                $instance.ValueType | Should Be $rule.ValueType
             }
         }
     }

--- a/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
+++ b/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
@@ -53,7 +53,6 @@ Describe 'xRegistry call' {
     {
         Context "$($testData.ValueType)" {
 
-            . $configFile
             function Get-RuleClassData {}
             Mock Get-RuleClassData -MockWith {$testData.testXml.Rule}
 

--- a/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
+++ b/Tests/Unit/DSCResources/windows.xRegistry.tests.ps1
@@ -1,0 +1,74 @@
+
+$testDataRules = @(
+    @{
+        testXml = [xml]'<Rule Id="V-1000" severity="low" title="DWORD Test">
+        <Ensure>Present</Ensure>
+        <IsNullOrEmpty>False</IsNullOrEmpty>
+        <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
+        <ValueData>0</ValueData>
+        <ValueName>DwordValueName</ValueName>
+        <ValueType>Dword</ValueType>
+        </Rule>'
+        ValueName = 'DwordValueName'
+        ValueData = '0'
+        ValueType = 'Dword'
+    },
+    @{
+        testXml = [xml]'<Rule id="V-1000" severity="low" title="MultiString Test">
+        <Ensure>Present</Ensure>
+        <IsNullOrEmpty>False</IsNullOrEmpty>
+        <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
+        <ValueData>123;ABC</ValueData>
+        <ValueName>MultiStringValueName</ValueName>
+        <ValueType>MultiString</ValueType>
+      </Rule>'
+        ValueName = 'MultiStringValueName'
+        ValueData = @('123', 'ABC')
+        ValueType = 'MultiString'
+    },
+    @{
+        testXml = [xml]'<Rule id="V-1000" severity="low" title="String">
+        <Ensure>Present</Ensure>
+        <IsNullOrEmpty>False</IsNullOrEmpty>
+        <Key>HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft</Key>
+        <ValueData>O:BAG:BAD:(A;;RC;;;BA)</ValueData>
+        <ValueName>StringValueName</ValueName>
+        <ValueType>String</ValueType>
+        </Rule>'
+        ValueName = 'StringValueName'
+        ValueData = 'O:BAG:BAD:(A;;RC;;;BA)'
+        ValueType = 'String'
+    }
+)
+
+$configFile = Join-Path -Path $PSScriptRoot -ChildPath "windows.xRegistry.config.ps1"
+. $configFile
+
+Describe 'xRegistry call' {
+
+    foreach ($testData in $testDataRules)
+    {
+        Context "$($testData.ValueType)" {
+
+            . $configFile
+            function Get-RuleClassData {}
+            Mock Get-RuleClassData -MockWith {$testData.testXml.Rule}
+
+            It 'Should not throw' {
+                { & xRegistry_config -OutputPath $TestDrive } | Should Not Throw
+            }
+
+            $configurationDocumentPath = "$TestDrive\localhost.mof"
+
+            $instance = [Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ImportInstances($configurationDocumentPath, 4)
+
+            It 'Should set the correct Type' {
+                $instance[0].ValueType | Should Be $testData.ValueType
+            }
+
+            It 'Should set the correct Data' {
+                $instance[0].ValueData | Should Be $testData.ValueData
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**
Fixes SDDL strings are incorrectly split in the xRegistry resource.

**This Pull Request (PR) fixes the following issues:**

This fixes #212 

**Task list:**

- [x] Change details added to Unreleased section of README.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/213)
<!-- Reviewable:end -->
