### PR TITLE
fixed HKCU cAdministrativeTemplateSetting composite issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed [#267](https://github.com/Microsoft/PowerStig/issues/267): Fixed winlogon registry path parser bug.
 * Fixed [#238](https://github.com/Microsoft/PowerStig/issues/238): Adds regex tracker for RegistryRule regex's.
 * Fixed [#274](https://github.com/Microsoft/PowerStig/issues/274): UserRightsAssignment composite resource does not leverage the Force Parameter.
+* Fixed [#280](https://github.com/Microsoft/PowerStig/issues/280): HKEY_CURRENT_USER is not needed with the cAdministrativeTemplateSetting composite resource.
 
 * Windows Server 2012R2 Fixes
   * V-36707 is now an org setting

--- a/DSCResources/Resources/windows.cAdministrativeTemplateSetting.ps1
+++ b/DSCResources/Resources/windows.cAdministrativeTemplateSetting.ps1
@@ -7,6 +7,7 @@ foreach ($rule in $rules)
 {
     if ($rule.Key -match "^HKEY_CURRENT_USER")
     {
+        $rule.Key = $rule.Key -replace 'HKEY_CURRENT_USER', ''
         if ($rule.ValueType -eq 'MultiString')
         {
             $valueData = $rule.ValueData.Split("{;}")
@@ -16,7 +17,7 @@ foreach ($rule in $rules)
             $valueData = $rule.ValueData
         }
 
-        if( $valueData -eq 'ShouldBeAbsent')
+        if ($valueData -eq 'ShouldBeAbsent')
         {
             $rule.Ensure = 'Absent'
         }


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**

HKEY_CURRENT_USER is not needed with the cAdministrativeTemplateSetting composite resource.

**This Pull Request (PR) fixes the following issues:**

This fixes #280 

**Task list:**

- [x] Change details added to Unreleased section of README.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/281)
<!-- Reviewable:end -->
