### PR TITLE
Duplicate and/or ExclusionRuleList Conversion Error -> Fixes #289

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed [#289](https://github.com/Microsoft/PowerStig/issues/289): Updated DocumentRule and DocumentRuleConvert Classes to parse correctly.
+
 * Introduces class support for each rule type
 * The STIG class now contains an array of rule objects vs xml elements
 * Orgsettings, Exceptions, and Rule skips are all supported by the Rule base class

--- a/Module/Rule.Document/Convert/DocumentRule.Convert.psm1
+++ b/Module/Rule.Document/Convert/DocumentRule.Convert.psm1
@@ -38,29 +38,6 @@ Class DocumentRuleConvert : DocumentRule
 
     <#
         .SYNOPSIS
-            Constructor that fully populates the required properties
-        .DESCRIPTION
-            Constructor that fully populates the required properties
-        .PARAMETER Id
-            The STIG ID
-        .PARAMETER Severity
-            The STIG Severity
-        .PARAMETER Title
-            The STIG Title
-        .PARAMETER RawString
-            The chcek-content element of the STIG xccdf
-    #>
-    DocumentRule ([string] $Id, [severity] $Severity, [string] $Title, [string] $RawString)
-    {
-        $this.Id = $Id
-        $this.severity = $Severity
-        $this.title = $Title
-        $this.rawString = $RawString
-        $this.DscResource = 'None'
-    }
-
-    <#
-        .SYNOPSIS
             Converts an existing rule into a document rule
         .DESCRIPTION
             Provides a way to convert stig rules that have already been parsed

--- a/Module/Rule.Document/DocumentRule.psm1
+++ b/Module/Rule.Document/DocumentRule.psm1
@@ -13,6 +13,29 @@ using module .\..\Rule\Rule.psm1
 #>
 Class DocumentRule : Rule
 {
+    <#
+        .SYNOPSIS
+            Constructor that fully populates the required properties
+        .DESCRIPTION
+            Constructor that fully populates the required properties
+        .PARAMETER Id
+            The STIG ID
+        .PARAMETER Severity
+            The STIG Severity
+        .PARAMETER Title
+            The STIG Title
+        .PARAMETER RawString
+            The chcek-content element of the STIG xccdf
+    #>
+    DocumentRule ([string] $Id, [severity] $Severity, [string] $Title, [string] $RawString)
+    {
+        $this.Id = $Id
+        $this.severity = $Severity
+        $this.title = $Title
+        $this.rawString = $RawString
+        $this.DscResource = 'None'
+    }
+    
     DocumentRule () {}
 
     DocumentRule ([xml.xmlelement] $Rule, [bool] $Convert) : Base ($Rule, $Convert) {}

--- a/Module/STIG/Convert/Functions.XccdfXml.ps1
+++ b/Module/STIG/Convert/Functions.XccdfXml.ps1
@@ -322,7 +322,7 @@ function Get-StigRuleList
     }
     process
     {
-        foreach ( $stigRule in $StigGroupList )
+        foreach ($stigRule in $StigGroupList)
         {
             # Global added so that the stig rule can be referenced later
             $global:stigRuleGlobal = $stigRule
@@ -333,9 +333,9 @@ function Get-StigRuleList
             {
                 $stigRule.rule.Check.('check-content') = $stigRule.rule.Check.('check-content') -replace [regex]::Escape($correction.oldText), $correction.newText
             }
-            $rules = [ConvertFactory]::Rule( $stigRule )
+            $rules = [ConvertFactory]::Rule($stigRule)
 
-            foreach ( $rule in $rules )
+            foreach ($rule in $rules)
             {
                 <#
                     At this point the original rule could be split into multiple
@@ -350,13 +350,13 @@ function Get-StigRuleList
                     $rule.RawString = $rule.RawString -replace [regex]::Escape($correction.newText), $correction.oldText
                 }
 
-                if ( $rule.title -match 'Duplicate' -or $exclusionRuleList.Contains(($rule.id -split '\.')[0]) )
+                if ($rule.title -match 'Duplicate' -or $exclusionRuleList.Contains(($rule.id -split '\.')[0]))
                 {
-                    [void] $global:stigSettings.Add( ( [DocumentRule]::ConvertFrom( $rule ) ) )
+                    [void] $global:stigSettings.Add(([DocumentRuleConvert]::ConvertFrom($rule)))
                 }
                 else
                 {
-                    [void] $global:stigSettings.Add( $rule )
+                    [void] $global:stigSettings.Add($rule)
                 }
             }
             $stigProcessedCounter ++


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**

Use PowerStig.Convert to convert a rule with duplicate in the title or set in the exclusionRuleList.
The conversion will throw two errors before outputting an converted xml file. (See screenshot below)

**This Pull Request (PR) fixes the following issues:**

This fixes #289 

**Task list:**

- [x] Change details added to Unreleased section of README.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/291)
<!-- Reviewable:end -->
