### PR TITLE
Fix for #331 - PermissionRule.Convert CheckContent Match Parser Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ UPDATES
 * Removed: Internet Explorer 1.13
 * Fixed [290](https://github.com/Microsoft/PowerStig/issues/290): [V-76731] IIS Server STIG V-76731 fails to properly set STIG guidance because rule is not split.
 * Fixed [314](https://github.com/Microsoft/PowerStig/issues/314): Update PowerSTIG to Utilize LogTargetW3C parameter in xWebAdministration 2.5.0.0.
+* Fixed [331](https://github.com/Microsoft/PowerStig/issues/331): 2012/R2 [V-39325] 2016 [V-73373], [V-73389] PermissionRule.Convert CheckContent Match Parser Update
 
 * Added the following STIGs
   * IIS Site 8.5 V1R6 [#276](https://github.com/Microsoft/PowerStig/issues/276)

--- a/Module/Rule.Permission/Convert/PermissionRule.Convert.psm1
+++ b/Module/Rule.Permission/Convert/PermissionRule.Convert.psm1
@@ -151,7 +151,7 @@ Class PermissionRuleConvert : PermissionRule
             $CheckContent -NotMatch 'user\srights\sand\spermissions' -and
             $CheckContent -NotMatch 'Query the SA' -and
             $CheckContent -NotMatch "caspol\.exe" -and
-            $CheckContent -NotMatch "Select the Group Policy object in the left pane" -and
+            $CheckContent -NotMatch "Select the Group Policy Object item in the left pane" -and
             $CheckContent -NotMatch "Deny log on through Remote Desktop Services" -and
             $CheckContent -NotMatch "Interview the IAM" -and
             $CheckContent -NotMatch "InetMgr\.exe" -and

--- a/StigData/Archive/Windows.Server.2012R2/U_Windows_2012_and_2012_R2_DC_STIG_V2R13_Manual-xccdf.log
+++ b/StigData/Archive/Windows.Server.2012R2/U_Windows_2012_and_2012_R2_DC_STIG_V2R13_Manual-xccdf.log
@@ -1,2 +1,3 @@
 V-2372::"Store password using reversible encryption"::"Store passwords using reversible encryption"
 V-6836::"Minimum password length,"::"Minimum password length"
+V-80475::Registry Path: \SOFTWARE\ Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\::Registry Path: \SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\

--- a/StigData/Archive/Windows.Server.2012R2/U_Windows_2012_and_2012_R2_DC_STIG_V2R14_Manual-xccdf.log
+++ b/StigData/Archive/Windows.Server.2012R2/U_Windows_2012_and_2012_R2_DC_STIG_V2R14_Manual-xccdf.log
@@ -1,2 +1,3 @@
 V-2372::"Store password using reversible encryption"::"Store passwords using reversible encryption"
 V-6836::"Minimum password length,"::"Minimum password length"
+V-80475::Registry Path: \SOFTWARE\ Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\::Registry Path: \SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\

--- a/StigData/Archive/Windows.Server.2012R2/U_Windows_2012_and_2012_R2_DC_STIG_V2R15_Manual-xccdf.log
+++ b/StigData/Archive/Windows.Server.2012R2/U_Windows_2012_and_2012_R2_DC_STIG_V2R15_Manual-xccdf.log
@@ -1,2 +1,3 @@
 V-2372::"Store password using reversible encryption"::"Store passwords using reversible encryption"
 V-6836::"Minimum password length,"::"Minimum password length"
+V-80475::Registry Path: \SOFTWARE\ Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\::Registry Path: \SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**

The CheckContent match in PermissionRule.Convert.psm1 currently has a string that is not found in any unprocessed xccdf xml. The following string $CheckContent -NotMatch "Select the Group Policy object in the left pane" should be $CheckContent -NotMatch "Select the Group Policy object item in the left pane". This will address 2012/R2 and 2016 DC STIG conversion issues. Specifically Rule Id "V-39325" (2012/R2), "V-73373", "V-73389" (2016).

**This Pull Request (PR) fixes the following issues:**

This fixes #331 

**Task list:**

- [x] Change details added to Unreleased section of README.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/332)
<!-- Reviewable:end -->
