### PR TITLE
HKEY_CURRENT_USER is not needed with the cAdministrativeTemplateSetting composite resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed [#373](https://github.com/Microsoft/PowerStig/issues/373): Registry resource does not handle null values for ValueData contained in Processed STIGs
 * Fixed [#376](https://github.com/Microsoft/PowerStig/issues/376): SQL STIG Rules V-41021 (Instance STIG) and V-41402 (Database STIG) fail to apply when applying to a SQL instance that is NOT name the default (MSSQLSERVER).
 * Fixed [#377](https://github.com/Microsoft/PowerStig/issues/377): SQL Instance Rule V-40936 fails when Set-TargertResource is ran
+* Fixed [#280](https://github.com/Microsoft/PowerStig/issues/280): HKEY_CURRENT_USER is not needed with the cAdministrativeTemplateSetting composite resource. (Regression Issue)
 
 ## 3.1.0
 

--- a/DSCResources/Resources/windows.cAdministrativeTemplateSetting.ps1
+++ b/DSCResources/Resources/windows.cAdministrativeTemplateSetting.ps1
@@ -7,6 +7,8 @@ foreach ($rule in $rules)
 {
     if ($rule.Key -match "^HKEY_CURRENT_USER")
     {
+        $rule.Key = $rule.Key -replace 'HKEY_CURRENT_USER', ''
+
         if ($rule.ValueType -eq 'MultiString')
         {
             $valueData = $rule.ValueData.Split("{;}")
@@ -16,7 +18,7 @@ foreach ($rule in $rules)
             $valueData = $rule.ValueData
         }
 
-        if( $valueData -eq 'ShouldBeAbsent')
+        if ($valueData -eq 'ShouldBeAbsent')
         {
             $rule.Ensure = 'Absent'
         }

--- a/Tests/Integration/DSCResources/Common.integration.ps1
+++ b/Tests/Integration/DSCResources/Common.integration.ps1
@@ -59,6 +59,18 @@ Describe ($title + " $($stig.StigVersion) mof output") {
                 }
             }
 
+            foreach ($mofEntry in $dscMof)
+            {
+                if ($mofEntry.ResourceID -match "cAdministrativeTemplateSetting")
+                {
+                    It "Should not contain the Hive in Key Path for $($mofEntry.ResourceID)" {
+                        $regexPattern = 'HKEY_CURRENT_USER|HKEY_CLASSES_ROOT|HKEY_LOCAL_MACHINE|HKEY_USERS|HKEY_CURRENT_CONFIG'
+                        $regKeyResult = $mofEntry.KeyValueName | Select-String -Pattern $regexPattern -AllMatches
+                        $regKeyResult.Matches.Count | Should Be 0
+                    }
+                }
+            }
+
             It "Should have $($ruleList.count) $ruleName settings" {
                 $hasAllRules | Should -Be $true
             }

--- a/Tests/Integration/DSCResources/Common.integration.ps1
+++ b/Tests/Integration/DSCResources/Common.integration.ps1
@@ -66,7 +66,7 @@ Describe ($title + " $($stig.StigVersion) mof output") {
                     It "Should not contain the Hive in Key Path for $($mofEntry.ResourceID)" {
                         $regexPattern = 'HKEY_CURRENT_USER|HKEY_CLASSES_ROOT|HKEY_LOCAL_MACHINE|HKEY_USERS|HKEY_CURRENT_CONFIG'
                         $regKeyResult = $mofEntry.KeyValueName | Select-String -Pattern $regexPattern -AllMatches
-                        $regKeyResult.Matches.Count | Should Be 0
+                        $regKeyResult.Matches.Count | Should -Be 0
                     }
                 }
             }

--- a/Tests/Integration/RegistryRule.Integration.tests.ps1
+++ b/Tests/Integration/RegistryRule.Integration.tests.ps1
@@ -177,11 +177,6 @@ try
                 It 'Should extract the correct key' {
                     $rule.key | Should Be $($registry.Hive + $registry.Path)
                 }
-                It 'Should contain one Hive' {
-                    $regexPattern = 'HKEY_CURRENT_USER|HKEY_CLASSES_ROOT|HKEY_LOCAL_MACHINE|HKEY_USERS|HKEY_CURRENT_CONFIG'
-                    $regKeyResult = $rule.key | Select-String -Pattern $regexPattern -AllMatches
-                    $regKeyResult.Count | Should Be 1
-                }
                 It 'Should extract the correct value name' {
                     $rule.valueName | Should Be $registry.ValueName
                 }

--- a/Tests/Integration/RegistryRule.Integration.tests.ps1
+++ b/Tests/Integration/RegistryRule.Integration.tests.ps1
@@ -177,6 +177,11 @@ try
                 It 'Should extract the correct key' {
                     $rule.key | Should Be $($registry.Hive + $registry.Path)
                 }
+                It 'Should contain one Hive' {
+                    $regexPattern = 'HKEY_CURRENT_USER|HKEY_CLASSES_ROOT|HKEY_LOCAL_MACHINE|HKEY_USERS|HKEY_CURRENT_CONFIG'
+                    $regKeyResult = $rule.key | Select-String -Pattern $regexPattern -AllMatches
+                    $regKeyResult.Count | Should Be 1
+                }
                 It 'Should extract the correct value name' {
                     $rule.valueName | Should Be $registry.ValueName
                 }


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**

HKEY_CURRENT_USER is not needed with the cAdministrativeTemplateSetting composite resource. This bug causes a Key to be created under HKCU called "HKEY_CURRENT_USER". Where all HKCU related STIG rules to be configured.

**This Pull Request (PR) fixes the following issues:**

This fixes #280 

**Task list:**

- [x] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/382)
<!-- Reviewable:end -->
