### PR TITLE
PowerShell package cannot be found in offline repository (package missing PSModule tag) #610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update PowerSTIG to use Azure Pipelines and DSC Community based build logic: [#600](https://github.com/microsoft/PowerStig/issues/600)
 * Update PowerSTIG to parse/convert the Vmware Vsphere 6.5 STIG V1R3: [#604](https://github.com/microsoft/PowerStig/issues/604)
+* Fixed PowerShell package cannot be found in offline repository. Added package missing PSModule tag: [#610](https://github.com/microsoft/PowerStig/issues/610): 
 
 ## [4.3.0] - 2020-03-27
 

--- a/source/PowerStig.psd1
+++ b/source/PowerStig.psd1
@@ -104,7 +104,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'DSC','DesiredStateConfiguration','STIG','PowerStig'
+        Tags = 'PSModule','DSC','DesiredStateConfiguration','STIG','PowerStig'
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/Microsoft/PowerStig/blob/master/LICENSE'


### PR DESCRIPTION
**Pull Request (PR) description:**
Add a metadata tag to allow the NuGet package provider to find the package in a local repository.

**This Pull Request (PR) fixes the following issues:**

This fixes #610 - PowerShell package cannot be found in offline repository

**Task list:**

- [X] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
- [ NA] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ NA] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [NA] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/611)
<!-- Reviewable:end -->
