### PR TITLE
ConvertTo-ManualCheckListHashTable function call is missing mandatory argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update PowerSTIG to Parse/Apply MS Office 365 ProPlus Ver 2, Rel 1: [#811](https://github.com/microsoft/PowerStig/issues/811)
 * Update PowerSTIG to Add Checklist Accountability: [#808](https://github.com/microsoft/PowerStig/issues/808)
 * Update PowerSTIG to move O365 Pro Plus log entries into Exclusion Rule list: [#815](https://github.com/microsoft/PowerStig/issues/815)
+* Fixed: ConvertTo-ManualCheckListHashTable function call is missing mandatory argument: [#823](https://github.com/microsoft/PowerStig/issues/823)
 
 ## [4.7.0] - 2020-12-17
 

--- a/source/Module/STIG/Functions.Checklist.ps1
+++ b/source/Module/STIG/Functions.Checklist.ps1
@@ -176,7 +176,7 @@ function New-StigCheckList
 
     if ($PSBoundParameters.ContainsKey('ManualChecklistEntriesFile'))
     {
-        $manualCheckData = ConvertTo-ManualCheckListHashTable -Path $ManualChecklistEntriesFile
+        $manualCheckData = ConvertTo-ManualCheckListHashTable -Path $ManualChecklistEntriesFile -XccdfPath $XccdfPath
     }
 
     # Values for some of these fields can be read from the .mof file or the DSC results file


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**

Fixes ConvertTo-ManualCheckListHashTable function call is missing mandatory argument

**This Pull Request (PR) fixes the following issues:**

This fixes #823 

**Task list:**

- [x] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/826)
<!-- Reviewable:end -->
