### PR TITLE
PowerShell v7 Fix: AccessControlDsc/RegistryAccessEntry & NTFSAccessEntry "AccessControlList" should be an Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Fixed: PowerShell v7 Fix: AccessControlDsc/RegistryAccessEntry & NTFSAccessEntry "AccessControlList" should be an Array
+
 ## [4.8.0] - 2021-03-01
 
 * Update PowerSTIG to remove old rule Ids in Hard Coded Framework: [#790](https://github.com/microsoft/PowerStig/issues/790)

--- a/source/DSCResources/Resources/windows.AccessControl.ps1
+++ b/source/DSCResources/Resources/windows.AccessControl.ps1
@@ -16,8 +16,7 @@ foreach ($rule in $rules)
             {
                 Path = $rule.Path
                 Force = $ruleForce
-                AccessControlList = $(
-
+                AccessControlList = @(
                     foreach ($acentry in $rule.AccessControlEntry.Entry)
                     {
                         $aceEntryForcePrincipal = $null
@@ -67,7 +66,7 @@ foreach ($rule in $rules)
             {
                 Path = $rule.Path
                 Force = $ruleForce
-                AccessControlList = $(
+                AccessControlList = @(
                     foreach ($acentry in $rule.AccessControlEntry.Entry)
                     {
                         $aceEntryForcePrincipal = $null


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**

PowerShell v7 Fix: AccessControlDsc/RegistryAccessEntry & NTFSAccessEntry "AccessControlList" should be an Array

**This Pull Request (PR) fixes the following issues:**

This fixes #868 

**Task list:**

- [x] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/869)
<!-- Reviewable:end -->
