### PR TITLE
windows.UserRightsAssignment.ps1 fix: Properly add Enterprise and Domain Admins to mof

### DIFF
--- a/Tests/Unit/Module/STIG.Checklist.tests.ps1
+++ b/Tests/Unit/Module/STIG.Checklist.tests.ps1
@@ -10,7 +10,7 @@ Describe 'New-StigCheckList' {
         (
             [parameter()]
             [string]
-            $NodeName = "localhost"
+            $NodeName = 'localhost'
         )
 
         Import-DscResource -ModuleName PowerStig
@@ -19,15 +19,17 @@ Describe 'New-StigCheckList' {
         {
             WindowsServer BaseLine
             {
-                OsVersion   = "2019"
-                OsRole      = "MS"
-                SkipRuleType = "AccountPolicyRule","AuditPolicyRule","AuditSettingRule","DocumentRule","ManualRule","PermissionRule","SecurityOptionRule","UserRightRule","WindowsFeatureRule","ProcessMitigationRule","RegistryRule"
+                OsVersion    = '2019'
+                OsRole       = 'MS'
+                DomainName   = 'Local'
+                ForestName   = 'Local'
+                SkipRuleType = 'AccountPolicyRule','AuditPolicyRule','AuditSettingRule','DocumentRule','ManualRule','PermissionRule','SecurityOptionRule','UserRightRule','WindowsFeatureRule','ProcessMitigationRule','RegistryRule'
             }
         }
     }
     Example -OutputPath $TestDrive
 
-    $mofTest = '{0}{1}' -f $TestDrive.fullname,"\localhost.mof"
+    $mofTest = '{0}{1}' -f $TestDrive.fullname,'\localhost.mof'
 
     # Test parameter validity -OutputPath
     It 'Should throw if an invalid path is provided' {
@@ -60,8 +62,8 @@ Describe 'New-StigCheckList' {
 
         {
             $outputPath = Join-Path $Testdrive -ChildPath Checklist.ckl
-            $xccdfPath = ((Get-ChildItem -Path $script:moduleRoot\StigData\Archive -Include *xccdf.xml -Recurse | Where-Object -Property Name -Match "Server_2019_MS")[1]).FullName
-            New-StigChecklist -ReferenceConfiguration $mofTest -XccdfPath $xccdfPath -OutputPath $outputPath -Verifier "PowerSTIG User 12/17/2020"
+            $xccdfPath = ((Get-ChildItem -Path $script:moduleRoot\StigData\Archive -Include *xccdf.xml -Recurse | Where-Object -Property Name -Match 'Server_2019_MS')[1]).FullName
+            New-StigChecklist -ReferenceConfiguration $mofTest -XccdfPath $xccdfPath -OutputPath $outputPath -Verifier 'PowerSTIG User 12/17/2020'
         } | Should -Not -Throw
     }
 }

--- a/source/DSCResources/Resources/windows.UserRightsAssignment.ps1
+++ b/source/DSCResources/Resources/windows.UserRightsAssignment.ps1
@@ -23,12 +23,9 @@ $forestGroupTranslation = @{
     'Schema Admins'             = '{0}\Schema Admins'
 }
 
-if ($DomainName -and $ForestName)
-{
-    # This requires a local forest and/or domain name to be injected to ensure a valid account name.
-    $DomainName = PowerStig\Get-DomainName -DomainName $DomainName -Format NetbiosName
-    $ForestName = PowerStig\Get-DomainName -ForestName $ForestName -Format NetbiosName
-}
+# This requires a local forest and/or domain name to be injected to ensure a valid account name.
+$DomainName = PowerStig\Get-DomainName -DomainName $DomainName -Format NetbiosName
+$ForestName = PowerStig\Get-DomainName -ForestName $ForestName -Format NetbiosName
 
 foreach ($rule in $rules)
 {


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**
This should allow the Enterprise Admins and Domain Admins to be added to identities in V-205672 for server 2019. 
Also, V-225015 and V-225557 for server 2016 and 2012R2 respectively.

**This Pull Request (PR) fixes the following issues:**

This fixes #909

**Task list:**

- [ ] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/910)
<!-- Reviewable:end -->
