### PR TITLE
PowerSTIG Convert should add newline to raw Xccdf to ensure Pester tests Pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* PowerSTIG Convert should add newline to raw Xccdf to ensure Pester tests Pass : [#1118](https://github.com/microsoft/PowerStig/issues/1118)
+
 ## [4.13.0] - 2022-06-16
 
 * Update PowerSTIG to successfully parse/apply Microsoft Windows 10 STIG - Ver 2, Rel 4: [#1096](https://github.com/microsoft/PowerStig/issues/1096)

--- a/source/Module/STIG/Convert/Functions.PowerStigXml.ps1
+++ b/source/Module/STIG/Convert/Functions.PowerStigXml.ps1
@@ -254,7 +254,7 @@ function ConvertTo-PowerStigXml
         $fileLength = $rawXccdf.Length
         $lastLine = $rawXccdf[$fileLength - 1]
 
-        if ($lastline -ne "")
+        if ($lastline -ne '')
         {
             Add-Content $path ''
         }

--- a/source/Module/STIG/Convert/Functions.PowerStigXml.ps1
+++ b/source/Module/STIG/Convert/Functions.PowerStigXml.ps1
@@ -249,6 +249,16 @@ function ConvertTo-PowerStigXml
     {
         $convertedStigObjects = ConvertFrom-StigXccdf -Path $Path -RuleIdFilter $RuleIdFilter
 
+        # Add a newline to end of raw xccdf if it doesn't exist
+        $rawXccdf = Get-Content -Path $Path
+        $fileLength = $rawXccdf.Length
+        $lastLine = $rawXccdf[$fileLength - 1]
+
+        if ($lastline -ne "")
+        {
+            Add-Content $path ''
+        }
+
         # Get the raw xccdf xml to pull additional details from the root node.
         [xml] $xccdfXml = Get-Content -Path $Path -Encoding UTF8
         [version] $stigVersionNumber = Get-StigVersionNumber -StigDetails $xccdfXml

--- a/source/Module/STIG/Convert/Functions.PowerStigXml.ps1
+++ b/source/Module/STIG/Convert/Functions.PowerStigXml.ps1
@@ -256,7 +256,7 @@ function ConvertTo-PowerStigXml
 
         if ($lastline -ne '')
         {
-            Add-Content $path ''
+            Add-Content -Path $path -Value ''
         }
 
         # Get the raw xccdf xml to pull additional details from the root node.


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**
PowerSTIG Convert should add newline to raw Xccdf to ensure Pester tests Pass

**This Pull Request (PR) fixes the following issues:**

This fixes #1118

**Task list:**

- [x] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerstig/1119)
<!-- Reviewable:end -->
