### PR TITLE
FIX: Add closing tag to IISServer-10.0-3.5 OrgSettings

### DIFF
--- a/source/StigData/Processed/IISServer-10.0-3.5.org.default.xml
+++ b/source/StigData/Processed/IISServer-10.0-3.5.org.default.xml
@@ -5,4 +5,4 @@
     Each setting in this file is linked by STIG ID and the valid range is in an
     associated comment.
 -->
-<OrganizationalSettings fullversion="3.5">
+<OrganizationalSettings fullversion="3.5" />


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR), your contribution is greatly appreciated!

Please prefix the PR title with the module name, i.e. 'Common: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: Common: My short description'

To aid reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->

**Pull Request (PR) description:**
Commit b07514f292123969467880db0ee2339e40474999, as part of PR #1517 and included in v4.28.0, mistakenly removed `/` from the XML self-closing tag inside the default IISServer-10.0-3.5 OrgSetting file -- making it an unclosed XML tag. **As a result, IISServer configuration will always fail due to unclosed XML tags.**

This PR is a small one -- it adds the `/` back to the IISServer-10.0-2.5 default settings file. Running IISServer configuration -- at least on my machines -- works again.

**This Pull Request (PR) fixes the following issues:**

This fully resolves the issues brought up in Issue #1504 that were intended to be solved in PR #1517. 

**Task list:**

- [ ] Change details added to Unreleased section of CHANGELOG.md (Not required for Convert modules)?
    - I will do this after a review/thumbs-up from others. The README.CONTRIBUTING.md pointed me to the wrong file to update, and I misread this question as being the same, non-existent changelog file.
- [ ] Added/updated documentation, comment-based help and descriptions where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] Unit and (optional) Integration tests created/updated where possible?

**Further notes:**
The removal of `/` in b07514f292123969467880db0ee2339e40474999 did not affect **3.4** (only **3.5**) because **3.4** was using full-closing XML tags, versus **3.5** which used self-closing XML tags.

It is perhaps worth noting that self-closing tags are used in several places for `OrganizationSettings`, such as in [the IE11 STIG](https://github.com/microsoft/PowerStig/blob/4.28.0-PSGallery/source/StigData/Processed/InternetExplorer-11-2.5.org.default.xml), so 3.4's usage of non-self-closing tags for an empty "body" seems a little out-of-the-ordinary. It's a nit-pick, but I would maybe like 3.4's configuration to be changed to a self-closing tag inline with the other XML files I've seen in this repo.
